### PR TITLE
Handle null Urls from unpublished nodes

### DIFF
--- a/VirtualNodes/VirtualNodesHelpers.cs
+++ b/VirtualNodes/VirtualNodesHelpers.cs
@@ -46,6 +46,8 @@ namespace VirtualNodes
         /// <returns>True if it is a virtual node</returns>
         public static bool IsVirtualNode(this IPublishedContent item)
         {
+            if (item == null) return false;
+            
             foreach (string rule in VirtualNodesRuleManager.Instance.Rules)
             {
                 if (MatchContentTypeAlias(item.ContentType.Alias, rule))

--- a/VirtualNodes/VirtualNodesUrlProvider.cs
+++ b/VirtualNodes/VirtualNodesUrlProvider.cs
@@ -69,8 +69,8 @@ namespace VirtualNodes
             // DO NOT USE THIS - RECURSES: string url = content.Url;
             // https://our.umbraco.org/forum/developers/extending-umbraco/73533-custom-url-provider-stackoverflowerror
             // https://our.umbraco.org/forum/developers/extending-umbraco/66741-iurlprovider-cannot-evaluate-expression-because-the-current-thread-is-in-a-stack-overflow-state
-            var url = base.GetUrl(umbracoContext, content, mode, culture, current);
-            var urlText = url.Text;
+            UrlInfo url = base.GetUrl(umbracoContext, content, mode, culture, current);
+            var urlText = url == null ? "" : url.Text;
 
             // If we come from an absolute URL, strip the host part and keep it so that we can append
             // it again when returing the URL. 
@@ -78,7 +78,7 @@ namespace VirtualNodes
 
             if (urlText.StartsWith("http"))
             {
-                var uri = new Uri(url.Text);
+                var uri = new Uri(urlText);
 
                 urlText = urlText.Replace(uri.GetLeftPart(UriPartial.Authority), "");
                 hostPart = uri.GetLeftPart(UriPartial.Authority);

--- a/VirtualNodes/VirtualNodesUrlProvider.cs
+++ b/VirtualNodes/VirtualNodesUrlProvider.cs
@@ -107,7 +107,7 @@ namespace VirtualNodes
                 var currentItem = umbracoContext.Content.GetById(int.Parse(pathIds[i]));
 
                 // Omit any virtual node unless it's leaf level (we still need this otherwise it will be pointing to parent's URL)
-                if (currentItem.IsVirtualNode() && i > 0)
+                if (currentItem != null && currentItem.IsVirtualNode() && i > 0)
                 {
                     urlParts[i] = "";
                 }


### PR DESCRIPTION
Fixes error that occurs if Umbraco is in preview mode.

An unpublished document will have a null url, which needs to be handled as a blank contribution to the url path.

This is a fix for [issue #1](https://github.com/christopherrobinson/Virtual-Nodes-for-Umbraco-8/issues/1).